### PR TITLE
Add short note to README on SSH and GuestIPHack ESXi reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 * [Packer](https://www.packer.io/intro/getting-started/install.html)
 
 
+> `packer` builds the OVA on a remote ESXi host via the [`vmware-iso`](https://www.packer.io/docs/builders/vmware-iso.html) builder. This builder requires the SSH service running on the ESXi host, as well as `GuestIPHack` enabled via `esxcli system settings advanced set -o /Net/GuestIPHack -i 1`
+
 Step 1 - Clone the git repository
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 * [Packer](https://www.packer.io/intro/getting-started/install.html)
 
 
-> `packer` builds the OVA on a remote ESXi host via the [`vmware-iso`](https://www.packer.io/docs/builders/vmware-iso.html) builder. This builder requires the SSH service running on the ESXi host, as well as `GuestIPHack` enabled via `esxcli system settings advanced set -o /Net/GuestIPHack -i 1`
+> `packer` builds the OVA on a remote ESXi host via the [`vmware-iso`](https://www.packer.io/docs/builders/vmware-iso.html) builder. This builder requires the SSH service running on the ESXi host, as well as `GuestIPHack` enabled via the command below.
+```
+esxcli system settings advanced set -o /Net/GuestIPHack -i 1
+```
 
 Step 1 - Clone the git repository
 


### PR DESCRIPTION
These seem to be required for the `vmware-iso` builder in remote mode. Thanks for sharing this setup! Very helpful stuff, especially your `rc.local` magic for pulling the custom vApp props!